### PR TITLE
Reduce the memory impact

### DIFF
--- a/FAForever.Replay.Benchmark/ReplayBenchmark.cs
+++ b/FAForever.Replay.Benchmark/ReplayBenchmark.cs
@@ -6,7 +6,7 @@ using BenchmarkDotNet.Diagnosers;
 namespace FAForever.Replay.Benchmark
 {
     [ShortRunJob]
-    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [MemoryDiagnoser]
     public class ReplayBenchmark
     {
         private static readonly string DirectoryWithReplays = "assets/faforever";

--- a/FAForever.Replay/CommandData.cs
+++ b/FAForever.Replay/CommandData.cs
@@ -1,5 +1,5 @@
 ﻿
 namespace FAForever.Replay
 {
-    public record struct CommandData(int Identifier, CommandType Type, CommandTarget Target, CommandFormation Formation, String BlueprintId, LuaData LuaParameters, Boolean AddToQueue, byte[] Unknown1, byte[] Unknown2, byte[] Unknown3, byte[] Unknown4);
+    public record struct CommandData(int Identifier, CommandType Type, CommandTarget Target, CommandFormation Formation, String BlueprintId, LuaData LuaParameters, Boolean AddToQueue, int Unknown1, int Unknown2, byte Unknown3, int Unknown4, int Unknown5, int Unknown6);
 }

--- a/FAForever.Replay/LuaDataLoader.cs
+++ b/FAForever.Replay/LuaDataLoader.cs
@@ -1,0 +1,59 @@
+﻿
+namespace FAForever.Replay
+{
+    public static class LuaDataLoader
+    {
+
+        public static LuaData ReadLuaData(ReplayBinaryReader reader)
+        {
+            LuaDataType type = (LuaDataType)reader.ReadByte();
+
+            switch (type)
+            {
+                case LuaDataType.Nil:
+                    return new LuaData.Nil();
+
+                case LuaDataType.Bool:
+                    return new LuaData.Bool(reader.ReadByte() == 0);
+
+                case LuaDataType.Number:
+                    return new LuaData.Number(reader.ReadSingle());
+
+                case LuaDataType.String:
+                    return new LuaData.String(reader.ReadNullTerminatedString());
+
+                case LuaDataType.TableStart:
+                    Dictionary<String, LuaData> table = new Dictionary<String, LuaData>();
+                    while (true)
+                    {
+                        LuaData key = ReadLuaData(reader);
+                        switch (key)
+                        {
+                            case LuaData.String s:
+                                table.Add(s.Value, ReadLuaData(reader));
+                                break;
+
+                            case LuaData.Number n:
+                                table.Add(((int)n.Value).ToString(), ReadLuaData(reader));
+                                break;
+
+                            case LuaData.Nil:
+                                return new LuaData.Table(table);
+
+                            default:
+                                throw new Exception("Invalid key type in table");
+                        }
+                    }
+
+                    throw new Exception("Invalid state exception");
+
+                case LuaDataType.TableEnd:
+                    return new LuaData.Nil();
+
+                default:
+                    throw new Exception("Invalid LuaDataType");
+            }
+        }
+
+    }
+}

--- a/FAForever.Replay/ReplayBinaryReader.cs
+++ b/FAForever.Replay/ReplayBinaryReader.cs
@@ -8,19 +8,11 @@ namespace FAForever.Replay
 {
     public class ReplayBinaryReader : BinaryReader
     {
-        public ReplayBinaryReader(Stream input) : base(input)
-        {
-            
-        }
+        public ReplayBinaryReader(Stream input) : base(input)  { }
 
-        public ReplayBinaryReader(Stream input, Encoding encoding) : base(input, encoding)
-        {
-            
-        }
+        public ReplayBinaryReader(Stream input, Encoding encoding) : base(input, encoding) { }
 
-        public ReplayBinaryReader(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen)
-        {
-        }
+        public ReplayBinaryReader(Stream input, Encoding encoding, bool leaveOpen) : base(input, encoding, leaveOpen) { }
 
         /// <summary>
         /// Reads bytes until it finds a null byte. Advances the stream with the size of the string.

--- a/FAForever.Replay/ReplayBinaryReader.cs
+++ b/FAForever.Replay/ReplayBinaryReader.cs
@@ -20,20 +20,16 @@ namespace FAForever.Replay
         /// <returns></returns>
         public string ReadNullTerminatedString()
         {
-            const int maximumStringSize = 128;
-            Span<byte> bytes = stackalloc byte[maximumStringSize];
+            StringBuilder sb = new StringBuilder();
 
-            byte b;
-            int index = 0;
-            while ((b = this.ReadByte()) != 0)
+            char c;
+            while ((c = this.ReadChar()) != '\0')
             {
-                if (index < maximumStringSize)
-                {
-                    bytes[index++] = b;
-                }
+                sb.Append(c);
             }
 
-            return Encoding.ASCII.GetString(bytes);
+
+            return sb.ToString();
         }
     }
 }

--- a/FAForever.Replay/ReplayInput.cs
+++ b/FAForever.Replay/ReplayInput.cs
@@ -82,7 +82,7 @@ namespace FAForever.Replay
         /// <param name="EntityId"></param>
         /// <param name="Arg1"></param>
         /// <param name="Arg2"></param>
-        public record struct ProcessInfoPair(int EntityId, String Arg1, String Arg2) : ReplayInput;
+        public record struct ProcessInfoPair(int EntityId, String Name, String Value) : ReplayInput;
 
         /// <summary>
         /// Created by the engine when the user creates a command by clicking
@@ -158,7 +158,7 @@ namespace FAForever.Replay
         /// <param name="func"></param>
         /// <param name="LuaParameters"></param>
         /// <param name="Units"></param>
-        public record struct SimCallback(String Endpoint, LuaData LuaParameters, CommandUnits Units, byte[] Unknown1, byte[] Unknown2) : ReplayInput;
+        public record struct SimCallback(String Endpoint, LuaData LuaParameters, CommandUnits Units) : ReplayInput;
 
         /// <summary>
         /// Created by the User global function `SessionEndGame`

--- a/FAForever.Replay/ReplayLoader.cs
+++ b/FAForever.Replay/ReplayLoader.cs
@@ -10,7 +10,6 @@ namespace FAForever.Replay
 {
     public static class ReplayLoader
     {
-
         public static List<ReplayInputToken> TokenizeBody(ReplayBinaryReader reader)
         {
             int tokenHeaderLength = 3;
@@ -47,12 +46,12 @@ namespace FAForever.Replay
 
             CommandFormation formation = ParseEventCommandFormation(reader);
 
-            string blueprintId = reader.ReadSCStringNullTerminated();
+            string blueprintId = reader.ReadNullTerminatedString();
 
             // unknown
             byte[] arg4 = reader.ReadBytes(12);
 
-            LuaData luaData = reader.ReadLuaData();
+            LuaData luaData = LuaDataLoader.ReadLuaData(reader);
 
             Boolean addToQueue = reader.ReadByte() > 0;
 
@@ -161,7 +160,7 @@ namespace FAForever.Replay
                         return new ReplayInput.CreateUnit
                         {
                             ArmyId = reader.ReadByte(),
-                            BlueprintId = reader.ReadSCStringNullTerminated(),
+                            BlueprintId = reader.ReadNullTerminatedString(),
                             X = reader.ReadSingle(),
                             Z = reader.ReadSingle(),
                             Heading = reader.ReadSingle()
@@ -170,7 +169,7 @@ namespace FAForever.Replay
                     case ReplayInputType.CreateProp:
                         return new ReplayInput.CreateProp
                         {
-                            BlueprintId = reader.ReadSCStringNullTerminated(),
+                            BlueprintId = reader.ReadNullTerminatedString(),
                             X = reader.ReadSingle(),
                             Z = reader.ReadSingle(),
                             Heading = reader.ReadSingle()
@@ -191,8 +190,8 @@ namespace FAForever.Replay
                     case ReplayInputType.ProcessInfoPair:
                         return new ReplayInput.ProcessInfoPair
                         {
-                            Arg1 = reader.ReadSCStringNullTerminated(),
-                            Arg2 = reader.ReadSCStringNullTerminated()
+                            Arg1 = reader.ReadNullTerminatedString(),
+                            Arg2 = reader.ReadNullTerminatedString()
                         };
 
                     case ReplayInputType.IssueCommand:
@@ -239,7 +238,7 @@ namespace FAForever.Replay
                         return new ReplayInput.UpdateCommandLuaParameters
                         {
                             CommandId = reader.ReadInt32(),
-                            LuaParameters = reader.ReadLuaData(),
+                            LuaParameters = LuaDataLoader.ReadLuaData(reader),
                             X = reader.ReadSingle(),
                             Y = reader.ReadSingle(),
                             Z = reader.ReadSingle()
@@ -255,7 +254,7 @@ namespace FAForever.Replay
                     case ReplayInputType.DebugCommand:
                         return new ReplayInput.DebugCommand
                         {
-                            Command = reader.ReadSCStringNullTerminated(),
+                            Command = reader.ReadNullTerminatedString(),
                             X = reader.ReadSingle(),
                             Y = reader.ReadSingle(),
                             Z = reader.ReadSingle(),
@@ -266,12 +265,12 @@ namespace FAForever.Replay
                     case ReplayInputType.ExecuteLuaInSim:
                         return new ReplayInput.ExecuteLuaInSim
                         {
-                            LuaCode = reader.ReadSCStringNullTerminated()
+                            LuaCode = reader.ReadNullTerminatedString()
                         };
 
                     case ReplayInputType.Simcallback:
-                        string endpoint = reader.ReadSCStringNullTerminated();
-                        LuaData luaParameters = reader.ReadLuaData();
+                        string endpoint = reader.ReadNullTerminatedString();
+                        LuaData luaParameters = LuaDataLoader.ReadLuaData(reader);
                         CommandUnits units = ParseEventCommandUnits(reader);
 
                         byte[] unknown1 = reader.ReadBytes(4);
@@ -304,17 +303,17 @@ namespace FAForever.Replay
 
         public static ReplayHeader ParseReplayHeader(ReplayBinaryReader reader)
         {
-            string gameVersion = reader.ReadSCStringNullTerminated();
+            string gameVersion = reader.ReadNullTerminatedString();
 
             // Always \r\n
-            string Unknown1 = reader.ReadSCStringNullTerminated();
+            string Unknown1 = reader.ReadNullTerminatedString();
 
-            String[] replayVersionAndScenario = reader.ReadSCStringNullTerminated().Split("\r\n");
+            String[] replayVersionAndScenario = reader.ReadNullTerminatedString().Split("\r\n");
             String replayVersion= replayVersionAndScenario[0];
             String pathToScenario = replayVersionAndScenario[1];
 
             // Always \r\n and an unknown character
-            string Unknown2 = reader.ReadSCStringNullTerminated();
+            string Unknown2 = reader.ReadNullTerminatedString();
 
             int numberOfBytesForMods = reader.ReadInt32();
             byte[] mods = reader.ReadBytes(numberOfBytesForMods);
@@ -326,7 +325,7 @@ namespace FAForever.Replay
             ReplaySource[] clients = new ReplaySource[numberOfClients];
             for (int i = 0; i < numberOfClients; i++)
             {
-                clients[i] = new ReplaySource(PlayerName: reader.ReadSCStringNullTerminated(), PlayerId: reader.ReadInt32());
+                clients[i] = new ReplaySource(PlayerName: reader.ReadNullTerminatedString(), PlayerId: reader.ReadInt32());
             }
 
             Boolean cheatsEnabled = reader.ReadByte() > 0;

--- a/README.md
+++ b/README.md
@@ -4,23 +4,27 @@ A small library to read and interpret replays of the game [Supreme Commander: Fo
 
 ## Performance
 
-We use the [BenchmarkDotNet](https://www.myget.org/feed/benchmarkdotnet/package/nuget/BenchmarkDotNet) library to generate basic statistics of the performance of the library as a whole. We do not generate statistics of individual functions since in practice you'll never call the individual functions - you'll always parse a replay as a single unit. 
+We use the [BenchmarkDotNet](https://www.myget.org/feed/benchmarkdotnet/package/nuget/BenchmarkDotNet) library to generate basic statistics of the performance of the library as a whole. We do not generate statistics of individual functions since in practice you'll never call the individual functions - you'll always parse a replay as a single unit.
 
 All files in `assets/faforever` are automatically part of the benchmark.
 
 _Benchmark data from 2024/09/04_
 
-| LoadReplay | 23225104.fafreplay   | 55.013 ms | 82.8102 ms | 4.5391 ms |
-| LoadReplay | 23225323.fafreplay   | 15.456 ms | 32.1467 ms | 1.7621 ms |
-| LoadReplay | 23225440.fafreplay   |  6.265 ms |  0.3651 ms | 0.0200 ms |
-| LoadReplay | 23225508.fafreplay   |  3.304 ms |  1.1702 ms | 0.0641 ms |
-| LoadReplay | 23225685.fafreplay   | 18.886 ms | 19.5360 ms | 1.0708 ms |
+| LoadReplay | 23225104.fafreplay | 55.013 ms | 82.8102 ms | 4.5391 ms |
+| LoadReplay | 23225323.fafreplay | 15.456 ms | 32.1467 ms | 1.7621 ms |
+| LoadReplay | 23225440.fafreplay | 6.265 ms | 0.3651 ms | 0.0200 ms |
+| LoadReplay | 23225508.fafreplay | 3.304 ms | 1.1702 ms | 0.0641 ms |
+| LoadReplay | 23225685.fafreplay | 18.886 ms | 19.5360 ms | 1.0708 ms |
 
 ## References
 
 The library attempts to use the latest and greatest of C#. This is made possible because of various books and online education content:
 
 - [Zoran Horvat](https://www.youtube.com/@zoran-horvat)
+- [dotnet](https://www.youtube.com/@dotnet)
+- - [A Complete .NET Developer's Guide to Span with Stephen Toub](https://www.youtube.com/watch?v=5KdICNWOfEQ)
+- [Raw coding](https://www.youtube.com/@RawCoding)
+- - [Understanding .NET C# Heaps (Deep Dive)](https://www.youtube.com/watch?v=TnDRzHZbOio)
 
 And relevant documentation:
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ We use the [BenchmarkDotNet](https://www.myget.org/feed/benchmarkdotnet/package/
 
 All files in `assets/faforever` are automatically part of the benchmark.
 
-_Benchmark data from 2024/09/01_
+_Benchmark data from 2024/09/04_
 
-| Method      | ReplayFile         | Mean      | Error    | StdDev   | Median    |
-|------------ |------------------- |----------:|---------:|---------:|----------:|
-| LoadReplays | 23225104.fafreplay | 167.85 ms | 3.353 ms | 3.293 ms | 166.50 ms |
-| LoadReplays | 23225323.fafreplay |  62.32 ms | 1.244 ms | 3.590 ms |  63.38 ms |
-| LoadReplays | 23225440.fafreplay |  16.34 ms | 0.176 ms | 0.147 ms |  16.33 ms |
-| LoadReplays | 23225508.fafreplay |  11.28 ms | 0.222 ms | 0.364 ms |  11.28 ms |
-| LoadReplays | 23225685.fafreplay |  64.65 ms | 1.419 ms | 4.182 ms |  64.79 ms |
+| LoadReplay | 23225104.fafreplay   | 55.013 ms | 82.8102 ms | 4.5391 ms |
+| LoadReplay | 23225323.fafreplay   | 15.456 ms | 32.1467 ms | 1.7621 ms |
+| LoadReplay | 23225440.fafreplay   |  6.265 ms |  0.3651 ms | 0.0200 ms |
+| LoadReplay | 23225508.fafreplay   |  3.304 ms |  1.1702 ms | 0.0641 ms |
+| LoadReplay | 23225685.fafreplay   | 18.886 ms | 19.5360 ms | 1.0708 ms |
 
 ## References
 


### PR DESCRIPTION
Removes the intermediate token and various other byte arrays to drastically reduce the number of allocated memory on the heap. The memory allocations are profiled using the built-in profiler of Visual Studio 2022 and via BenchmarkDotNet. See also the reference section in the readme.

Before:

| ReplayFile           | Mean      | Error     | StdDev   | Gen0      | Gen1      | Gen2      | Allocated |
|--------------------- |----------:|----------:|---------:|----------:|----------:|----------:|----------:|
| 23225104.fafreplay   | 168.52 ms | 25.965 ms | 1.423 ms | 4000.0000 | 3666.6667 | 1333.3333 | 158.37 MB |
| 23225323.fafreplay   |  61.37 ms | 25.634 ms | 1.405 ms | 2500.0000 | 2375.0000 | 1250.0000 |  78.53 MB |
| 23225440.fafreplay   |  17.21 ms |  4.253 ms | 0.233 ms | 1625.0000 | 1593.7500 |  968.7500 |  37.03 MB |
| 23225508.fafreplay   |  12.10 ms | 11.488 ms | 0.630 ms | 1250.0000 | 1234.3750 |  796.8750 |  25.46 MB |
| 23225685.fafreplay   |  64.36 ms | 72.872 ms | 3.994 ms | 2500.0000 | 2375.0000 | 1125.0000 |   79.8 MB |
| TestC(...)eplay [24] |  58.77 ms | 33.523 ms | 1.837 ms | 2000.0000 | 1888.8889 | 1000.0000 |   59.9 MB |

After: 

| ReplayFile           | Mean      | Error      | StdDev    | Gen0      | Gen1      | Gen2      | Allocated |
|--------------------- |----------:|-----------:|----------:|----------:|----------:|----------:|----------:|
| 23225104.fafreplay   | 53.056 ms | 11.4210 ms | 0.6260 ms | 1909.0909 | 1818.1818 | 1272.7273 |  56.88 MB |
| 23225323.fafreplay   | 14.862 ms | 30.0466 ms | 1.6470 ms | 1000.0000 |  968.7500 |  781.2500 |  23.13 MB |
| 23225440.fafreplay   |  6.382 ms |  0.9361 ms | 0.0513 ms | 1109.3750 | 1101.5625 |  992.1875 |   9.51 MB |
| 23225508.fafreplay   |  3.282 ms |  0.9536 ms | 0.0523 ms |  703.1250 |  699.2188 |  644.5313 |   5.56 MB |
| 23225685.fafreplay   | 19.225 ms | 30.5515 ms | 1.6746 ms |  937.5000 |  906.2500 |  687.5000 |  25.16 MB |
| TestC(...)eplay [24] | 14.766 ms | 26.3337 ms | 1.4434 ms |  718.7500 |  687.5000 |  500.0000 |  19.49 MB |