### PR TITLE
Feature/processing in stages

### DIFF
--- a/FAForever.Replay.Benchmark/FAForeverReplayBenchmark.cs
+++ b/FAForever.Replay.Benchmark/FAForeverReplayBenchmark.cs
@@ -36,8 +36,7 @@ namespace FAForever.Replay.Benchmark
             byte[] replayData = AllReplays[ReplayFile];
             using (MemoryStream stream = new MemoryStream(replayData))
             {
-                IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-                ReplayLoader.LoadFAFReplayFromMemory(stream, progress);
+                ReplayLoader.LoadFAFReplayFromMemory(stream);
             }
         }
     }

--- a/FAForever.Replay.Benchmark/SCFAReplayBenchmark.cs
+++ b/FAForever.Replay.Benchmark/SCFAReplayBenchmark.cs
@@ -36,8 +36,7 @@ namespace FAForever.Replay.Benchmark
             byte[] replayData = AllReplays[ReplayFile];
             using (MemoryStream stream = new MemoryStream(replayData))
             {
-                IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-                ReplayLoader.LoadSCFAReplayFromStream(stream, progress);
+                ReplayLoader.LoadSCFAReplayFromStream(stream);
             }
         }
     }

--- a/FAForever.Replay.Sandbox/Program.cs
+++ b/FAForever.Replay.Sandbox/Program.cs
@@ -54,13 +54,11 @@ namespace FAForever.Replay.Sandbox
             {
                 if (isFAForeverReplay)
                 {
-                    IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>((s) => Console.WriteLine($" - {s} at {DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond}"));
-                    return ReplayLoader.LoadFAFReplayFromMemory(replayStream, progress);
+                    return ReplayLoader.LoadFAFReplayFromMemory(replayStream);
                 }
                 else
                 {
-                    IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>((s) => Console.WriteLine($" - {s} at {DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond}"));
-                    return ReplayLoader.LoadSCFAReplayFromStream(replayStream, progress);
+                    return ReplayLoader.LoadSCFAReplayFromStream(replayStream);
                 }
             }
         }
@@ -77,8 +75,7 @@ namespace FAForever.Replay.Sandbox
             byte[] content = await response.Content.ReadAsByteArrayAsync();
             using MemoryStream replayStream = new MemoryStream(content);
             {
-                IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>((s) => Console.WriteLine($" - {s} at {DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond}"));
-                return ReplayLoader.LoadFAFReplayFromMemory(replayStream, progress);
+                return ReplayLoader.LoadFAFReplayFromMemory(replayStream);
             }
         }
 

--- a/FAForever.Replay.Test/ReplayLoaderTest.cs
+++ b/FAForever.Replay.Test/ReplayLoaderTest.cs
@@ -9,8 +9,7 @@ public class ReplayLoaderTest
     [DataRow("assets/faforever/zstd/22425616.fafreplay")]
     public void FAForeverZSTDTest(string file)
     {
-        IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file, progress);
+        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file);
         Assert.IsNotNull(replay);
     }
 
@@ -20,8 +19,7 @@ public class ReplayLoaderTest
     [DataRow("assets/faforever/gzip/22453511.fafreplay")]
     public void FAForeverGZipTest(string file)
     {
-        IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file, progress);
+        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file);
         Assert.IsNotNull(replay);
     }
 
@@ -40,8 +38,7 @@ public class ReplayLoaderTest
     [DataRow("assets/faforever/23225104.fafreplay", 51017)]
     public void FAForeverUserInputCountTest(string file, int expectedCount)
     {
-        IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file, progress);
+        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file);
         Assert.AreEqual(expectedCount, replay.Body.UserInput.Count);
     }
 
@@ -51,8 +48,7 @@ public class ReplayLoaderTest
     [DataRow("assets/scfa/balthazar-03.SCFAReplay", 12077)]
     public void SCFAUserInputCountTest(string file, int expectedCount)
     {
-        IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-        Replay replay = ReplayLoader.LoadSCFAReplayFromDisk(file, progress);
+        Replay replay = ReplayLoader.LoadSCFAReplayFromDisk(file);
         Assert.AreEqual(expectedCount, replay.Body.UserInput.Count);
     }
 
@@ -62,8 +58,7 @@ public class ReplayLoaderTest
     [DataRow("assets/faforever/gzip/22453511.fafreplay", 3)]
     public void FAForeverChatMessageCountTest(string file, int expectedCount)
     {
-        IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file, progress);
+        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file);
         List<ReplayChatMessage> chatMessages = ReplaySemantics.GetChatMessages(replay);
         Assert.AreEqual(expectedCount, chatMessages.Count);
     }
@@ -72,8 +67,7 @@ public class ReplayLoaderTest
     [DataRow("assets/faforever/mods.fafreplay", 2)]
     public void FAForeverModCountTest(string file, int expectedCount)
     {
-        IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file, progress);
+        Replay replay = ReplayLoader.LoadFAFReplayFromDisk(file);
 
         // TODO
     }
@@ -82,8 +76,7 @@ public class ReplayLoaderTest
     [DataRow("assets/scfa/21stGameOceanScampsV2.SCFAReplay", 0)]
     public void SCFAModCountTest(string file, int expectedCount)
     {
-        IProgress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>();
-        Replay replay = ReplayLoader.LoadSCFAReplayFromDisk(file, progress);
+        Replay replay = ReplayLoader.LoadSCFAReplayFromDisk(file);
 
         // TODO
     }

--- a/FAForever.Replay.Viewer/Features/ReplayLoadDialog.razor
+++ b/FAForever.Replay.Viewer/Features/ReplayLoadDialog.razor
@@ -12,7 +12,7 @@
             <MudListItem Icon="@Icons.Material.Filled.Info" Text="Scenario"
                 SecondaryText="@TranslateText(TimeScenario)" />
             <MudListItem Icon="@Icons.Material.Filled.Input" Text="User input"
-                SecondaryText="@TranslateText(TimeInput)" />
+                SecondaryText="@GetInputStatus()" />
         </MudList>
 
         <MudProgressLinear Color="Color.Secondary" Indeterminate="true" Class="my-7" />
@@ -34,6 +34,7 @@
     private float? TimeCompression = null;
     private float? TimeScenario = null;
     private float? TimeInput = null;
+    private float? PercentageInput = null;
 
     private void Submit() => MudDialog.Close(DialogResult.Ok(true));
 
@@ -46,6 +47,18 @@
         }
 
         return $"Done ({time.GetValueOrDefault().ToString("0.00")}ms)";
+    }
+
+    private string GetInputStatus() {
+        if (TimeInput.HasValue) {
+            return $"{TimeInput.GetValueOrDefault():0.00}ms";
+        }
+
+        if (PercentageInput.HasValue) {
+            return $"{PercentageInput.GetValueOrDefault():0.00}%";
+        }
+
+        return "N/A";
     }
 
     protected override void OnInitialized()
@@ -73,12 +86,12 @@
                     stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.NotStarted)stage);
                     this.TimeMetadata = stopwatch.ElapsedMilliseconds;
                     this.StateHasChanged();
-                    await Task.Delay(1);
+                    await Task.Delay(10);
 
                     stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.WithMetadata)stage);
                     this.TimeCompression = stopwatch.ElapsedMilliseconds;
                     this.StateHasChanged();
-                    await Task.Delay(1);
+                    await Task.Delay(10);
                     break;
 
                 case ReplayType.SCFA:
@@ -96,8 +109,14 @@
 
             stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.WithScenario)stage);
 
-            while (stage is ReplayLoadingStage.AtInput)
-                stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.AtInput)stage);
+            while (stage is ReplayLoadingStage.AtInput inputStage) {
+                this.PercentageInput = (float)(inputStage.BodyInvariant.PercentageProcessed);
+                this.StateHasChanged();
+                await Task.Delay(1);
+
+                stage = ReplayLoader.ProcessReplayStage(inputStage);
+                await Task.Delay(1);
+            }
 
             this.TimeInput = stopwatch.ElapsedMilliseconds;
             this.StateHasChanged();

--- a/FAForever.Replay.Viewer/Features/ReplayLoadDialog.razor
+++ b/FAForever.Replay.Viewer/Features/ReplayLoadDialog.razor
@@ -7,12 +7,15 @@
     </TitleContent>
     <DialogContent>
         <MudList T="string">
-            <MudListItem Icon="@Icons.Material.Filled.Compress" Text="Compression" SecondaryText="@TranslateText(Status.Decompression, Status.DecompressionTime)" />
-            <MudListItem Icon="@Icons.Material.Filled.Info" Text="Scenario" SecondaryText="@TranslateText(Status.Header, Status.HeaderTime)" />
-            <MudListItem Icon="@Icons.Material.Filled.Input" Text="User input" SecondaryText="@TranslateText(Status.Body, Status.BodyTime)" />
+            <MudListItem Icon="@Icons.Material.Filled.Compress" Text="Compression"
+                SecondaryText="@TranslateText(TimeCompression)" />
+            <MudListItem Icon="@Icons.Material.Filled.Info" Text="Scenario"
+                SecondaryText="@TranslateText(TimeScenario)" />
+            <MudListItem Icon="@Icons.Material.Filled.Input" Text="User input"
+                SecondaryText="@TranslateText(TimeInput)" />
         </MudList>
 
-        <MudProgressLinear Color="Color.Secondary" Indeterminate="true" Class="my-7"/>
+        <MudProgressLinear Color="Color.Secondary" Indeterminate="true" Class="my-7" />
     </DialogContent>
 </MudDialog>
 
@@ -27,50 +30,82 @@
     [Parameter]
     public MemoryStream Stream { get; set; }
 
-    public ReplayLoadProgression Status {get;set;} = new ReplayLoadProgression();
+    private float? TimeMetadata = null;
+    private float? TimeCompression = null;
+    private float? TimeScenario = null;
+    private float? TimeInput = null;
 
     private void Submit() => MudDialog.Close(DialogResult.Ok(true));
 
     private void Cancel() => MudDialog.Cancel();
 
-    private string TranslateText(ReplayLoadStatus status, float time) {
-        switch (status) {
-            case ReplayLoadStatus.Success:
-                return $"Done ({time.ToString("0.00")}ms)";
-            case ReplayLoadStatus.NotStarted:
-                return $"Not started";
-            case ReplayLoadStatus.Pending:
-                return $"Pending...";
-            case ReplayLoadStatus.NotApplicable:
-                return $"(Not applicable)";
-            default:
-                return "";
+    private string TranslateText(float? time)
+    {
+        if (time is null) {
+            return "";
         }
+
+        return $"Done ({time.GetValueOrDefault().ToString("0.00")}ms)";
     }
 
-    protected override void OnInitialized() {
+    protected override void OnInitialized()
+    {
         this.MudDialog.SetOptions(new DialogOptions() { CloseButton = true, FullWidth = true, MaxWidth = MaxWidth.Medium });
     }
 
-    protected override async Task OnAfterRenderAsync (bool firstRender) {
-        if (!firstRender){
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
             return;
         }
 
-        Progress<ReplayLoadProgression> progress = new Progress<ReplayLoadProgression>((status) => { this.Status = status; this.StateHasChanged(); Console.WriteLine(DateTime.Now);});
+        await Task.Run(async () =>
+        {
+            Stopwatch stopwatch = new Stopwatch();
 
-        await Task.Run(() => {
-            switch(Type) {
+            stopwatch.Start();
+            ReplayLoadingStage stage = new ReplayLoadingStage.NotStarted(this.Stream);
+
+            switch (Type)
+            {
                 case ReplayType.FAForever:
-                    ReplayService.LoadFAForeverReplay(Stream, progress);
+                    stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.NotStarted)stage);
+                    this.TimeMetadata = stopwatch.ElapsedMilliseconds;
+                    this.StateHasChanged();
+                    await Task.Delay(1);
+
+                    stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.WithMetadata)stage);
+                    this.TimeCompression = stopwatch.ElapsedMilliseconds;
+                    this.StateHasChanged();
+                    await Task.Delay(1);
                     break;
 
                 case ReplayType.SCFA:
-                    ReplayService.LoadSCFAReplay(Stream, progress);
+                    stage = new ReplayLoadingStage.Decompressed(Stream, null);
                     break;
 
                 default:
                     break;
+            }
+
+            stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.Decompressed)stage);
+            this.TimeScenario = stopwatch.ElapsedMilliseconds;
+            this.StateHasChanged();
+            await Task.Delay(1);
+
+            stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.WithScenario)stage);
+
+            while (stage is ReplayLoadingStage.AtInput)
+                stage = ReplayLoader.ProcessReplayStage((ReplayLoadingStage.AtInput)stage);
+
+            this.TimeInput = stopwatch.ElapsedMilliseconds;
+            this.StateHasChanged();
+            await Task.Delay(1);
+
+            if (stage is ReplayLoadingStage.Complete completed)
+            {
+                Replay replay = new Replay(completed.Header, completed.Body);
             }
         });
 

--- a/FAForever.Replay.Viewer/Services/ReplayService.cs
+++ b/FAForever.Replay.Viewer/Services/ReplayService.cs
@@ -43,16 +43,16 @@ namespace FAForever.Replay.Viewer.Services
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
-        public void LoadSCFAReplay(MemoryStream stream, IProgress<ReplayLoadProgression> progress)
+        public void LoadSCFAReplay(MemoryStream stream)
         {
-            this.Replay = ReplayLoader.LoadSCFAReplayFromStream(stream, progress);
+            this.Replay = ReplayLoader.LoadSCFAReplayFromStream(stream);
             this.ChatMessages = ReplaySemantics.GetChatMessages(this.Replay).AsReadOnly();
         }
 
 
-        public void LoadFAForeverReplay(MemoryStream stream, IProgress<ReplayLoadProgression> progress)
+        public void LoadFAForeverReplay(MemoryStream stream)
         {
-            this.Replay = ReplayLoader.LoadFAFReplayFromMemory(stream, progress);
+            this.Replay = ReplayLoader.LoadFAFReplayFromMemory(stream);
             this.ChatMessages = ReplaySemantics.GetChatMessages(this.Replay).AsReadOnly();
         }
     }

--- a/FAForever.Replay.Viewer/_Imports.razor
+++ b/FAForever.Replay.Viewer/_Imports.razor
@@ -16,3 +16,5 @@
 @using Phork.Blazor
 
 @using MudBlazor
+
+@using System.Diagnostics;

--- a/FAForever.Replay/ReplayBodyInvariant.cs
+++ b/FAForever.Replay/ReplayBodyInvariant.cs
@@ -1,10 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace FAForever.Replay
+﻿namespace FAForever.Replay
 {
-    public record ReplayBodyInvariant(List<ReplayInput> Input, int Tick, int Source, bool InSync, int HashTick, long HashValue, bool EndOfStream);
+
+    /// <summary>
+    /// Represents the invariant of the loop of processing the input of a replay. This allows the process to exit periodically, make room for other code to run, and then continue where it left off. This is useful for single threaded environments such as WebAssembly that is used by Blazor.
+    /// </summary>
+    /// <param name="input"></param>
+    /// <param name="tick"></param>
+    /// <param name="source"></param>
+    /// <param name="inSync"></param>
+    /// <param name="hashTick"></param>
+    /// <param name="hashValue"></param>
+    /// <param name="endOfStream"></param>
+    /// <param name="startingPointOfStream"></param>
+    /// <param name="percentageProcessed"></param>
+    public record ReplayBodyInvariant(List<ReplayInput> input, int tick, int source, bool inSync, int hashTick, long hashValue, bool endOfStream, long startingPointOfStream, int percentageProcessed)
+    {
+        public List<ReplayInput> Input { get; init; } = input;
+
+        public int Tick { get; init; } = tick;
+
+        public int Source { get; init; } = source;
+
+        public bool InSync { get; init; } = inSync;
+
+        public int HashTick { get; init; } = hashTick;
+
+        public long HashValue { get; init; } = hashValue;
+
+        public bool EndOfStream { get; init; } = endOfStream;
+
+        public long StartingPointOfStream { get; init; } = startingPointOfStream;
+
+        public int PercentageProcessed { get; init; } = percentageProcessed;
+    }
 }

--- a/FAForever.Replay/ReplayBodyInvariant.cs
+++ b/FAForever.Replay/ReplayBodyInvariant.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FAForever.Replay
+{
+    public record ReplayBodyInvariant(List<ReplayInput> Input, int Tick, int Source, bool InSync, int HashTick, long HashValue, bool EndOfStream);
+}

--- a/FAForever.Replay/ReplayLoader.cs
+++ b/FAForever.Replay/ReplayLoader.cs
@@ -107,6 +107,9 @@ namespace FAForever.Replay
             int hashTick = 0;
             long hashValue = 0;
 
+            // progress
+            long startingPointOfStream = reader.BaseStream.Position;
+
             List<ReplayInput> replayInputs;
             if (invariant is not null)
             {
@@ -116,6 +119,7 @@ namespace FAForever.Replay
                 hashTick = invariant.HashTick;
                 hashValue = invariant.HashValue;
                 replayInputs = invariant.Input;
+                startingPointOfStream = invariant.StartingPointOfStream;
             }
             else
             {
@@ -338,7 +342,9 @@ namespace FAForever.Replay
                     break;
                 }
             }
-            return new ReplayBodyInvariant(replayInputs, currentTick, currentSource, inSync, hashTick, hashValue, reader.BaseStream.Position == reader.BaseStream.Length);
+
+            int completionPercentage = (int)Math.Round(100 * ((float)reader.BaseStream.Position - startingPointOfStream) / (reader.BaseStream.Length - startingPointOfStream));
+            return new ReplayBodyInvariant(replayInputs, currentTick, currentSource, inSync, hashTick, hashValue, reader.BaseStream.Position == reader.BaseStream.Length, startingPointOfStream, completionPercentage);
         }
 
         private static ReplayScenarioMap LoadScenarioMap(LuaData.Table luaScenario)
@@ -504,7 +510,9 @@ namespace FAForever.Replay
         }
 
         /// <summary>
-        /// Processes the metadata of a replay from FAForever and returns the intermediate results.
+        /// Processes the metadata of a replay from FAForever and returns the intermediate results. 
+        /// 
+        /// This allows the process to exit periodically, make room for other code to run, and then continue where it left off. This is useful for single threaded environments such as WebAssembly that is used by Blazor.
         /// </summary>
         /// <param name="stage"></param>
         /// <returns></returns>
@@ -524,6 +532,8 @@ namespace FAForever.Replay
 
         /// <summary>
         /// Decompresses the replay and returns the intermediate results.
+        /// 
+        /// This allows the process to exit periodically, make room for other code to run, and then continue where it left off. This is useful for single threaded environments such as WebAssembly that is used by Blazor.
         /// </summary>
         /// <param name="stage"></param>
         /// <returns></returns>
@@ -549,6 +559,8 @@ namespace FAForever.Replay
 
         /// <summary>
         /// Processes the scenario of a replay and returns the intermediate results.
+        /// 
+        /// This allows the process to exit periodically, make room for other code to run, and then continue where it left off. This is useful for single threaded environments such as WebAssembly that is used by Blazor.
         /// </summary>
         /// <param name="stage"></param>
         /// <returns></returns>
@@ -561,6 +573,8 @@ namespace FAForever.Replay
 
         /// <summary>
         /// Processes a portion of the input of a replay and returns the intermediate results.
+        /// 
+        /// This allows the process to exit periodically, make room for other code to run, and then continue where it left off. This is useful for single threaded environments such as WebAssembly that is used by Blazor.
         /// </summary>
         /// <param name="stage"></param>
         /// <returns></returns>
@@ -572,6 +586,8 @@ namespace FAForever.Replay
 
         /// <summary>
         /// Processes a portion of the input of a replay and returns the intermediate results.
+        /// 
+        /// This allows the process to exit periodically, make room for other code to run, and then continue where it left off. This is useful for single threaded environments such as WebAssembly that is used by Blazor.
         /// </summary>
         /// <param name="stage"></param>
         /// <returns></returns>

--- a/FAForever.Replay/ReplayLoadingStage.cs
+++ b/FAForever.Replay/ReplayLoadingStage.cs
@@ -1,0 +1,19 @@
+
+using FAForever.Replay;
+
+public abstract record ReplayLoadingStage
+{
+    public sealed record NotStarted(MemoryStream Stream) : ReplayLoadingStage;
+
+    public sealed record WithMetadata(MemoryStream Stream, ReplayMetadata Metadata) : ReplayLoadingStage;
+
+    public sealed record Decompressed(MemoryStream Stream, ReplayMetadata? Metadata): ReplayLoadingStage;
+
+    public sealed record WithScenario(ReplayBinaryReader Stream, ReplayMetadata? Metadata, ReplayHeader Header) : ReplayLoadingStage;
+
+    public sealed record AtInput(ReplayBinaryReader Stream, ReplayMetadata? Metadata, ReplayHeader Header, ReplayBodyInvariant BodyInvariant) : ReplayLoadingStage;
+
+    public sealed record Complete(ReplayBinaryReader Stream, ReplayMetadata? Metadata, ReplayHeader Header, ReplayBody Body) : ReplayLoadingStage;
+
+    public sealed record Failed(string Message) : ReplayLoadingStage;
+}

--- a/FAForever.Replay/ReplayMetadata.cs
+++ b/FAForever.Replay/ReplayMetadata.cs
@@ -1,5 +1,50 @@
 ﻿
+using System.Text.Json.Serialization;
+
 namespace FAForever.Replay
 {
-    public record ReplayMetadata();
+    public record ReplayMetadata() {
+
+        [JsonPropertyName("complete")]
+        public bool Complete { get; init; }
+        
+        [JsonPropertyName("featured_mod")]
+        public string FeaturedMod { get; init; }
+
+        [JsonPropertyName("game_end")]
+        public double game_end { get; init; }
+
+        [JsonPropertyName("game_type")]
+        public string GameType { get; init; }
+
+        [JsonPropertyName("host")]
+        public string host { get; init; }
+
+        [JsonPropertyName("launched_at")]
+        public double launched_at { get; init; }
+
+        [JsonPropertyName("mapname")]
+        public string mapname { get; init; }
+
+        [JsonPropertyName("num_players")]
+        public int num_players { get; init; }
+
+        [JsonPropertyName("recorder")]
+        public string recorder { get; init; }
+
+        [JsonPropertyName("state")]
+        public string state { get; init; }
+
+        [JsonPropertyName("title")]
+        public string title { get; init; }
+
+        [JsonPropertyName("uid")]
+        public int uid { get; init; }
+
+        [JsonPropertyName("compression")]
+        public string compression { get; init; }
+
+        [JsonPropertyName("version")]
+        public int version { get; init; }
+    }
 }


### PR DESCRIPTION
WebAssembly is single threaded. And the Blazor framework compiles to WebAssembly. Therefore it is single threaded too. One consequence of this is that long running processes, even when they run as an async task, will block the UI from updating. And we happen to have such a long running process - interpreting the replay!

The replay loader class now exposes new functions that enables interpreting the replay in chunks. This in turn allows us to occasionally update the UI in between. The old approach introduces by #6 where [IProgress](https://learn.microsoft.com/en-us/dotnet/api/system.iprogress-1?view=net-8.0) interface was used as explained by [Zoran Horvat](https://www.youtube.com/watch?v=dhleFJPOQOs) is removed from the implementation. If you're interested in updating the interface in between then you can instead use the new approach. This simplifies the code quite a bit 😄 !